### PR TITLE
Improved Chat Commands

### DIFF
--- a/BCDiaperWetter.js
+++ b/BCDiaperWetter.js
@@ -27,6 +27,20 @@ DiaperUseMessages =
     "ChangeDiaperBoth": " has gotten a fresh pair of diapers."
 };
 
+// Table to store all the defaul values for diaperWetter()
+const diaperDefaultValues = 
+{
+    messChance: .3,
+    wetChance: .5,
+    baseTimer: 30,
+    regressionLevel: 0,
+    desperationLevel: 0,
+    messLevelInner: 0,
+    wetLevelInner: 0,
+    messLevelOuter: 0,
+    wetLevelOuter: 0
+};
+
 diaperLoop = null;         // Keeps a hold of the loop so it can be exited at any time easily
 
 // Destutter speach. Needed for interations with other mods
@@ -70,45 +84,135 @@ function bcdw(data)
             (data.Type === "Chat" || data.Type === "Whisper")
         )
         {
-            bcdwCommands(destutter(data?.Content).substring(9, data.Content.length), data.Sender);
+            // Parse out data into a queue for easier processing
+            chatCommand = data?.Content.split(" ");
+            chatCommand.shift();
+
+            // Send to command parser
+            bcdwCommands(chatCommand.reverse(), data.Sender);
         }
     }
 }
 
 // Command handler
-function bcdwCommands(data, callerID)
+function bcdwCommands(chatCommand, callerID)
 {
-    console.log(data);
     // Commands only the user can use
     if (callerID === Player.MemberNumber)
     {
         // Start the script
-        if (data.startsWith("start"))
+        if (chatCommand[chatCommand.length-1] === "start")
         {
-            diaperWetter();
+            // Check to see if other arguments have been passed as well (default regression level, desperation, or use levels)
+            chatCommand.pop()
+
+            // Parse arguments for command
+            let commandArguments = ["WetChance", "MessChance", "Desperation", "Regression", "Timer", "WetPanties", "MessPanties", "WetChastity", "MessChastity"];
+            let caughtArguments = {};
+            while (commandArguments.includes(chatCommand[chatCommand.length-1]))
+            {
+                let tempVal = chatCommand.pop();
+                switch (tempVal)
+                {
+                    case commandArguments[0]:
+                        caughtArguments.wetChance = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetChance : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[1]:
+                        caughtArguments.messChance = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messChance : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[2]:
+                        caughtArguments.desperationLevel = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.desperationLevel : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[3]:
+                        caughtArguments.regressionLevel = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.regressionLevel : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[4]:
+                        caughtArguments.baseTimer = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.baseTimer : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[5]:
+                        caughtArguments.wetLevelInner = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetLevelInner : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[6]:
+                        caughtArguments.messLevelInner = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messLevelInner : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[7]:
+                        caughtArguments.wetLevelOuter = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetLevelOuter : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[8]:
+                        caughtArguments.messLevelOuter = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messLevelOuter : chatCommand[chatCommand.length-1];
+                        break;
+                }
+                chatCommand.pop();
+            }
+
+            console.log(caughtArguments);
+            diaperWetter(caughtArguments);
         }
 
         // End the script
-        if (data.startsWith("stop"))
+        else if (chatCommand[chatCommand.length-1] === "stop")
         {
             stopWetting();
         }
     }
+
+    // If the user is called out
+    else if (data.startsWith(toString(Player.MemberNumber)))
+    {
+        // Clip off the memeber number
+        data = data.substring(toString(Player.MemberNumber).length + 1, data.length);
+
+        if (data.startsWith("change"))
+        {
+            if (data.substring(7, data.length).startsWith("inner"))
+            {
+                refreshDiaper("panites");
+            }
+            else if (data.substring(7, data.length).startsWith("outer"))
+            {
+                refreshDiaper("chastity");
+            }
+            else
+            {
+                refreshDiaper();
+            }
+        }
+    }
 }
 
-
-
 // Initializer function
-function diaperWetter()
+function diaperWetter( args =
+    {
+        messChance: diaperDefaultValues.messChance,
+        wetChance: diaperDefaultValues.wetChance,
+        baseTimer: diaperDefaultValues.baseTimer,
+        regressionLevel: diaperDefaultValues.regressionLevel,
+        desperationLevel: diaperDefaultValues.desperationLevel,
+        messLevelInner: diaperDefaultValues.messLevelInner,
+        wetLevelInner: diaperDefaultValues.wetLevelInner,
+        messLevelOuter: diaperDefaultValues.messLevelOuter,
+        wetLevelOuter: diaperDefaultValues.wetLevelOuter
+    }
+)
 {
+    // Greating message
     ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: "Say hello to the little baby " + Player.Name + "!"}]});
+
     // Initial clear. Only time "both" should be used for refreshDiaper.
-    refreshDiaper("both");
-    messThreshold = .7;             // 1-chance to mess
-    wetThreshold = .5;              // 1-chance to wet
-    diaperTimerBase = 30;           // The default amount of time between ticks in minutes
-    regressionLevel = 0;            // Used for tracking how much the user has regressed (affects the timer)
-    desperationLevel = 0;           // Used for tracking how recently a milk bottle has been used (affects the timer)
+    refreshDiaper(
+    {
+        _diaper: "both",
+        _wetLevelChastity: (args.wetLevelOuter < 0 || args.wetLevelOuter > 2) ? diaperDefaultValues.wetLevelOuter : (args.wetLevelOuter > args.messLevelOuter) ? args.wetLevelOuter : args.messLevelOuter,
+        _messLevelChastity: (args.messLevelOuter < 0 || args.messLevelOuter > 2) ? diaperDefaultValues.messLevelOuter : args.messLevelOuter,
+        _wetLevelPanties: (args.wetLevelInner < 0 || args.wetLevelInner > 2) ? diaperDefaultValues.wetLevelInner : (args.wetLevelInner > args.messLevelInner) ? args.wetLevelInner : args.messLevelInner,
+        _messLevelPanties: (args.messLevelInner < 0 || args.messLevelInner > 2) ? diaperDefaultValues.messLevelInner : args.messLevelInner
+    });
+
+    messChance = args.messChance;
+    wetChance = args.wetChance;
+    diaperTimerBase = args.baseTimer;   // The default amount of time between ticks in minutes
+    regressionLevel = args.regressionLevel;// Used for tracking how much the user has regressed (affects the timer)
+    desperationLevel = args.desperationLevel;// Used for tracking how recently a milk bottle has been used (affects the timer)
     
 
     // Handle modifiers
@@ -133,14 +237,22 @@ function changeDiaperTimer(delay)
 }
 
 // Refresh the diaper settings so wet and mess levels are 0. Pass "chastity", "panties", or "both" so only the correct diaper gets reset.
-function refreshDiaper(diaper = "both")
-{
-    if (diaper === "both")
+function refreshDiaper({_diaper, _wetLevelPanties, _messLevelPanties, _wetLevelChastity, _messLevelChastity} =
     {
-        MessLevelPanties = 0;
-        WetLevelPanties = 0;
-        MessLevelChastity = 0;
-        WetLevelChastity = 0;
+        _diaper: "both",
+        _wetLevelPanties: diaperDefaultValues.wetLevelInner,
+        _messLevelPanties: diaperDefaultValues.messLevelInner,
+        _wetLevelChastity: diaperDefaultValues.wetLevelOuter,
+        _messLevelChastity: diaperDefaultValues.messLevelOuter,
+    }
+)
+{
+    if (_diaper === "both")
+    {
+        MessLevelPanties = _messLevelPanties;
+        WetLevelPanties = _wetLevelPanties;
+        MessLevelChastity = _messLevelChastity;
+        WetLevelChastity = _wetLevelChastity;
         changeDiaperColor("ItemPelvis");
         changeDiaperColor("Panties");
         if (checkForDiaper("Panties") && checkForDiaper("ItemPelvis"))
@@ -152,10 +264,10 @@ function refreshDiaper(diaper = "both")
             ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + DiaperUseMessages["ChangeDiaperOnly"]}]});
         }
     }
-    else if (diaper === "chastity")
+    else if (_diaper === "chastity")
     {
-        MessLevelChastity = 0;
-        WetLevelChastity = 0;
+        MessLevelChastity = _messLevelChastity;
+        WetLevelChastity = _wetLevelChastity;
         changeDiaperColor("ItemPelvis");
         if (checkForDiaper("ItemPelvis") && checkForDiaper("Panties"))
         {
@@ -166,10 +278,10 @@ function refreshDiaper(diaper = "both")
             ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + DiaperUseMessages["ChangeDiaperOnly"]}]});
         }
     }
-    else if (diaper === "panties")
+    else if (_diaper === "panties")
     {
-        MessLevelPanties = 0;
-        WetLevelPanties = 0;
+        MessLevelPanties = _messLevelPanties;
+        WetLevelPanties = _wetLevelPanties;
         changeDiaperColor("Panties");
         if (checkForDiaper("ItemPelvis") && checkForDiaper("Panties"))
         {
@@ -203,7 +315,7 @@ function checkForMilk()
 // Handles the regression counter
 function manageRegression(diaperTimerModifier = 1)
 {
-    if (checkForNurseryMilk() && regressionLevel < 6)
+    if (checkForNurseryMilk() && regressionLevel < 3)
     {
         regressionLevel++;
     }
@@ -309,7 +421,7 @@ function diaperTick()
 
     testMess = Math.random();
     // If the baby messes, increment the mess level to a max of 2 and make sure that the wet level is at least as high as the mess level.
-    if (testMess > messThreshold)
+    if (testMess > 1-messChance)
     {
         if (MessLevelPanties === 2 || !checkForDiaper("Panties"))
         {
@@ -352,7 +464,7 @@ function diaperTick()
         }
     }
     // If the baby only wets, increment the wet level to a max of 2.
-    else if (testMess > wetThreshold)
+    else if (testMess > 1-wetChance)
     {
         if (WetLevelPanties == 2 && (InventoryGet(Player, "Panties") !== "PoofyDiaper" && InventoryGet(Player, "Panties") !== "BulkyDiaper"))
         {

--- a/TODO
+++ b/TODO
@@ -3,13 +3,13 @@ BUG PRIORITY:
 
 HIGH PRIORITY:
 ✔ Chat messages when diaper is used. @done(22-02-27 20:25)
-☐ Chat based imports.
+✔ Chat based imports. @done(22-03-01 20:52)
 
 MEDIUM PRIORITY
 ☐ Generalize. Generalize. Generalize.
-    ☐ Make it so the timer length can be adjusted.
+    ✔ Make it so the timer length can be adjusted. @done(22-03-01 20:52)
 ☐ Separate front and back coloring.
-☐ Package based deployment.
+✔ Package based deployment. @done(22-02-27 22:53)
 
 LOW PRIORITY:
 ☐ UI configurator.


### PR DESCRIPTION
# Purpose of commit
This commit expands the `->diaper start` command by allowing it to take in arguments, listed below.
- Regression - sets initial regression level. Useful for when you want to start out highly incontinent.
- Desperation - sets the initial desperation level. Primary use is for when you're already drinking from a bottle when executing the command
- WetPanties/MessPanties/WetChastity/MessChastity - sets the initial use values for a diaper. Useful for if you needed to pause the script for a length of time and want to resume it, instead of restarting. Can also be used if you want to RP having just woken up and needing a change.
- WetChance/MessChance - determines how likely a "tick" is to make you wet/mess. Both should be between 0 and 1 (decimal probility) and WetChance should be higher than MessChance. Default values are 0.5 for WetChance and 0.3 for MessChance.
- Timer - sets the base tick rate for the script. This sets the length of 1 tick in minutes when both Desperation and Regression are at 0. Default value is 30.

# Mechanical Changes
- Expanded `->diaper start` command as described above.
- Decreased max regression level from 6 to 3. This means with the default base timer and no desperation, the tick time will be at ~4 minutes with max regression instead of ~30 seconds.

# Known Issues
- `->diaper start` allows for setting higher or lower than normal levels of timer, desperation and regression. While this won't cause any major technical errors for regression and timer, it WILL cause unintended behavior if negative values are input for desperation.
- Still no way to force a tick or refresh a diaper from the chat box :c

# Technical Changes
- Converted `bcdwCommand()` to use a stack instead of a string. This makes processing more complex commands easier.
- Gave `diaperWetter()` and `refreshDiaper()` named arguments. This was necessary in order for the defaults to be passed in the `diaper start` command function properly, and later may be used for loading in preferences (i.e. for custom use pallets or default usage chances).