### PR TITLE
Chat commands

### DIFF
--- a/BCDiaperWetter.js
+++ b/BCDiaperWetter.js
@@ -89,13 +89,13 @@ function bcdw(data)
             chatCommand.shift();
 
             // Send to command parser
-            bcdwCommands(chatCommand.reverse(), data.Sender);
+            bcdwCommands(chatCommand.reverse(), data.Sender, data.Type);
         }
     }
 }
 
 // Command handler
-function bcdwCommands(chatCommand, callerID)
+function bcdwCommands(chatCommand, callerID, type)
 {
     // Commands only the user can use
     if (callerID === Player.MemberNumber)
@@ -115,37 +115,35 @@ function bcdwCommands(chatCommand, callerID)
                 switch (tempVal)
                 {
                     case commandArguments[0]:
-                        caughtArguments.wetChance = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetChance : chatCommand[chatCommand.length-1];
+                        caughtArguments.initWetChance = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetChance : chatCommand[chatCommand.length-1];
                         break;
                     case commandArguments[1]:
-                        caughtArguments.messChance = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messChance : chatCommand[chatCommand.length-1];
+                        caughtArguments.initMessChance = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messChance : chatCommand[chatCommand.length-1];
                         break;
                     case commandArguments[2]:
-                        caughtArguments.desperationLevel = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.desperationLevel : chatCommand[chatCommand.length-1];
+                        caughtArguments.initDesperationLevel = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.desperationLevel : chatCommand[chatCommand.length-1];
                         break;
                     case commandArguments[3]:
-                        caughtArguments.regressionLevel = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.regressionLevel : chatCommand[chatCommand.length-1];
+                        caughtArguments.initRegressionLevel = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.regressionLevel : chatCommand[chatCommand.length-1];
                         break;
                     case commandArguments[4]:
                         caughtArguments.baseTimer = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.baseTimer : chatCommand[chatCommand.length-1];
                         break;
                     case commandArguments[5]:
-                        caughtArguments.wetLevelInner = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetLevelInner : chatCommand[chatCommand.length-1];
+                        caughtArguments.initWetLevelInner = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetLevelInner : chatCommand[chatCommand.length-1];
                         break;
                     case commandArguments[6]:
-                        caughtArguments.messLevelInner = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messLevelInner : chatCommand[chatCommand.length-1];
+                        caughtArguments.initMessLevelInner = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messLevelInner : chatCommand[chatCommand.length-1];
                         break;
                     case commandArguments[7]:
-                        caughtArguments.wetLevelOuter = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetLevelOuter : chatCommand[chatCommand.length-1];
+                        caughtArguments.initWetLevelOuter = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetLevelOuter : chatCommand[chatCommand.length-1];
                         break;
                     case commandArguments[8]:
-                        caughtArguments.messLevelOuter = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messLevelOuter : chatCommand[chatCommand.length-1];
+                        caughtArguments.initMessLevelOuter = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messLevelOuter : chatCommand[chatCommand.length-1];
                         break;
                 }
                 chatCommand.pop();
             }
-
-            console.log(caughtArguments);
             diaperWetter(caughtArguments);
         }
 
@@ -155,41 +153,119 @@ function bcdwCommands(chatCommand, callerID)
             stopWetting();
         }
     }
+    // Chat commands that can be executed by other people
+    {
+        // Filter to make sure the command is targeted at the user
+        if (chatCommand[chatCommand.length-2] === Player.MemberNumber || type === "Whisper" || callerID === Player.MemberNumber)
+        {
+            // Change into a fresh diaper
+            if (chatCommand[chatCommand.length-1] === "change")
+            {
+                chatCommand.pop();
+
+                // Get rid of the member number in case that was passed
+                if (chatCommand[chatCommand.length-1] === Player.MemberNumber)
+                {
+                    chatCommand.pop();
+                }
+
+                // See if you should be changing both or just one of the diaper (and which one, of course)
+                if (chatCommand[chatCommand.length-1] === "panties")
+                {
+                    if (!checkForDiaper("panties"))
+                    {
+                        ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + " doesn't have a diaper there!"}]});
+                    }
+                    else
+                    {
+                        refreshDiaper({cdiaper: "panties"});
+                    }
+                }
+                else if (chatCommand[chatCommand.length-1] === "chastity")
+                {
+                    if (!checkForDiaper === "chastity")
+                    {
+                        ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + " doesn't have a diaper there!"}]});
+                    }
+                    else
+                    {
+                        refreshDiaper({cdiaper: "chastity"});
+                    }
+                }
+                else
+                {
+                    if (!(checkForDiaper("panties") || checkForDiaper("chastity")))
+                    {
+                        ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + " doesn't have a diaper! Get one on her before she makes a mess!"}]});
+                    }
+                    else
+                    {
+                        refreshDiaper({cdiaper: "both"});
+                    }
+                }
+            }
+        }
+    }
 }
 
 // Initializer function
-function diaperWetter( args =
+function diaperWetter( 
     {
-        messChance: diaperDefaultValues.messChance,
-        wetChance: diaperDefaultValues.wetChance,
-        baseTimer: diaperDefaultValues.baseTimer,
-        regressionLevel: diaperDefaultValues.regressionLevel,
-        desperationLevel: diaperDefaultValues.desperationLevel,
-        messLevelInner: diaperDefaultValues.messLevelInner,
-        wetLevelInner: diaperDefaultValues.wetLevelInner,
-        messLevelOuter: diaperDefaultValues.messLevelOuter,
-        wetLevelOuter: diaperDefaultValues.wetLevelOuter
-    }
+        initMessChance = diaperDefaultValues.messChance,
+        initWetChance = diaperDefaultValues.wetChance,
+        baseTimer = diaperDefaultValues.baseTimer,
+        initRegressionLevel = diaperDefaultValues.regressionLevel,
+        initDesperationLevel = diaperDefaultValues.desperationLevel,
+        initMessLevelInner = diaperDefaultValues.messLevelInner,
+        initWetLevelInner = diaperDefaultValues.wetLevelInner,
+        initMessLevelOuter = diaperDefaultValues.messLevelOuter,
+        initWetLevelOuter = diaperDefaultValues.wetLevelOuter
+    } = {}
 )
 {
     // Greating message
     ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: "Say hello to the little baby " + Player.Name + "!"}]});
 
-    // Initial clear. Only time "both" should be used for refreshDiaper.
-
+    // Initial clear.
     refreshDiaper(
     {
-        diaper: "both",
-        messLevelChastity: (isNaN(args.messLevelOuter) || (args.messLevelOuter < 0 || args.messLevelOuter > 2)) ? diaperDefaultValues.messLevelOuter : args.messLevelOuter,
-        wetLevelChastity: (isNaN(args.wetLevelOuter) || (args.wetLevelOuter < 0 || args.wetLevelOuter > 2)) ? (isNaN(args.messLevelOuter) || (args.messLevelOuter < 0 || args.messLevelOuter > 2)) ? diaperDefaultValues.messLevelOuter : args.messLevelOuter : (args.wetLevelOuter > args.messLevelOuter) ? args.wetLevelOuter : args.messLevelOuter,
-        messLevelPanties: (isNaN(args.messLevelInner) || (args.messLevelInner < 0 || args.messLevelInner > 2)) ? diaperDefaultValues.messLevelInner : args.messLevelInner,
-        wetLevelPanties: (isNaN(args.wetLevelInner) || (args.wetLevelInner < 0 || args.wetLevelInner > 2)) ? (isNaN(args.messLevelInner) || (args.messLevelInner < 0 || args.messLevelInner > 2)) ? diaperDefaultValues.messLevelInner : args.messLevelOuter : (args.wetLevelInner > args.messLevelInner) ? args.wetLevelInner : args.messLevelInner
+        cdiaper: "both",
+        inMessLevelChastity: (initMessLevelOuter < 0 || initMessLevelOuter > 2) ? 
+            diaperDefaultValues.messLevelOuter : 
+            initMessLevelOuter,
+        inWetLevelChastity: (initWetLevelOuter < 0 || initWetLevelOuter > 2) ? 
+            ((initMessLevelOuter < 0 || initMessLevelOuter > 2) ? 
+                diaperDefaultValues.messLevelOuter : 
+                inMessLevelOuter
+            ) : 
+            ((initWetLevelOuter > initMessLevelOuter) ? 
+                initWetLevelOuter : 
+                ((initMessLevelOuter < 0 || initMessLevelOuter > 2) ? 
+                    diaperDefaultValues.messLevelOuter : 
+                    initMessLevelOuter
+                )
+            ),
+        inMessLevelPanties: (initMessLevelInner < 0 || initMessLevelInner > 2) ? 
+            diaperDefaultValues.messLevelInner : 
+            initMessLevelInner,
+        inWetLevelPanties: (initWetLevelInner < 0 || initWetLevelInner > 2) ? 
+            ((initMessLevelInner < 0 || initMessLevelInner > 2) ? 
+                diaperDefaultValues.messLevelInner : 
+                initMessLevelOuter
+            ) : 
+            ((initWetLevelInner > initMessLevelInner) ? 
+                initWetLevelInner : 
+                ((initMessLevelInner < 0 || initMessLevelInner > 2) ? 
+                    diaperDefaultValues.messLevelInner : 
+                    initMessLevelInner
+                )
+            ),
     });
-    messChance = args.messChance;
-    wetChance = args.wetChance;
-    diaperTimerBase = args.baseTimer;   // The default amount of time between ticks in minutes
-    regressionLevel = args.regressionLevel;// Used for tracking how much the user has regressed (affects the timer)
-    desperationLevel = args.desperationLevel;// Used for tracking how recently a milk bottle has been used (affects the timer)
+    messChance = initMessChance;
+    wetChance = initWetChance;
+    diaperTimerBase = baseTimer;   // The default amount of time between ticks in minutes
+    regressionLevel = initRegressionLevel;// Used for tracking how much the user has regressed (affects the timer)
+    desperationLevel = initDesperationLevel;// Used for tracking how recently a milk bottle has been used (affects the timer)
     
 
     // Handle modifiers
@@ -214,26 +290,22 @@ function changeDiaperTimer(delay)
 }
 
 // Refresh the diaper settings so wet and mess levels are 0. Pass "chastity", "panties", or "both" so only the correct diaper gets reset.
-function refreshDiaper(args =
+function refreshDiaper(
     {
-        diaper: "both",
-        wetLevelPanties: diaperDefaultValues.wetLevelInner,
-        messLevelPanties: diaperDefaultValues.messLevelInner,
-        wetLevelChastity: diaperDefaultValues.wetLevelOuter,
-        messLevelChastity: diaperDefaultValues.messLevelOuter,
-    }
+        cdiaper = "both",
+        inWetLevelPanties = diaperDefaultValues.wetLevelInner,
+        inMessLevelPanties =  diaperDefaultValues.messLevelInner,
+        inWetLevelChastity = diaperDefaultValues.wetLevelOuter,
+        inMessLevelChastity = diaperDefaultValues.messLevelOuter,
+    } = {}
 )
 {
-    if (args.diaper === "both")
+    if (cdiaper === "both")
     {
-        console.log(args.wetLevelPanties);
-        console.log(args.messLevelPanties);
-        console.log(args.wetLevelChastity);
-        console.log(args.messLevelChastity);
-        MessLevelPanties = args.messLevelPanties;
-        WetLevelPanties = args.wetLevelPanties;
-        MessLevelChastity = args.messLevelChastity;
-        WetLevelChastity = args.wetLevelChastity;
+        MessLevelPanties = inMessLevelPanties;
+        WetLevelPanties = inWetLevelPanties;
+        MessLevelChastity = inMessLevelChastity;
+        WetLevelChastity = inWetLevelChastity;
         changeDiaperColor("ItemPelvis");
         changeDiaperColor("Panties");
         if (checkForDiaper("Panties") && checkForDiaper("ItemPelvis"))
@@ -245,10 +317,10 @@ function refreshDiaper(args =
             ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + DiaperUseMessages["ChangeDiaperOnly"]}]});
         }
     }
-    else if (args.diaper === "chastity")
+    else if (cdiaper === "chastity")
     {
-        MessLevelChastity = args.messLevelChastity;
-        WetLevelChastity = args.wetLevelChastity;
+        MessLevelChastity = inMessLevelChastity;
+        WetLevelChastity = inWetLevelChastity;
         changeDiaperColor("ItemPelvis");
         if (checkForDiaper("ItemPelvis") && checkForDiaper("Panties"))
         {
@@ -259,10 +331,10 @@ function refreshDiaper(args =
             ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + DiaperUseMessages["ChangeDiaperOnly"]}]});
         }
     }
-    else if (args.diaper === "panties")
+    else if (cdiaper === "panties")
     {
-        MessLevelPanties = args.messLevelPanties;
-        WetLevelPanties = args.wetLevelPanties;
+        MessLevelPanties = inMessLevelPanties;
+        WetLevelPanties = inWetLevelPanties;
         changeDiaperColor("Panties");
         if (checkForDiaper("ItemPelvis") && checkForDiaper("Panties"))
         {

--- a/BCDiaperWetter.js
+++ b/BCDiaperWetter.js
@@ -33,12 +33,24 @@ function diaperWetter()
     ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: "Say hello to the little baby " + Player.Name + "!"}]});
     // Initial clear. Only time "both" should be used for refreshDiaper.
     refreshDiaper("both");
-    messThreshold = .7;
-    wetThreshold = .5;
+    messThreshold = .7;             // 1-chance to mess
+    wetThreshold = .5;              // 1-chance to wet
+    diaperTimerBase = 30*60*1000;   // The default amount of time between ticks
+    diaperTimer = diaperTimerBase;  // The actual time between ticks (may be affected by)
 
     // Go into main loop
-    diaperRunning = true;
+    diaperRunning = true;           // Helps with the kill switch
     checkTick();
+}
+
+// Changes how long it takes between ticks (in minutes)
+function changeDiaperTimer(delay)
+{
+    // Bound the delay to between 2 minutes and 1 hour
+    if (delay < 2) { delay = 2; }
+    else if (delay > 60) { delay = 60; }
+
+    diaperTimerBase = delay;        // Updates diaperTimerBase
 }
 
 // Refresh the diaper settings so wet and mess levels are 0. Pass "chastity", "panties", or "both" so only the correct diaper gets reset.

--- a/BCDiaperWetter.js
+++ b/BCDiaperWetter.js
@@ -154,7 +154,7 @@ function manageDesperation(diaperTimerModifier = 1)
         // Decrease desperation to a minimum of zero if no milk is found
         desperation = (desperation != 0) ? desperation - 1 : 0;
     }
-    return diaperTimerModifier * desperation;
+    return diaperTimerModifier * (desperation+1);
 }
 
 // Updates the color of a diaper

--- a/BCDiaperWetter.js
+++ b/BCDiaperWetter.js
@@ -27,6 +27,54 @@ DiaperUseMessages =
     "ChangeDiaperBoth": " has gotten a fresh pair of diapers."
 };
 
+// Chat handeler
+ServerSocket.on("ChatRoomMessage", bcdw);
+function bcdw(data)
+{
+    // First, make sure there's actually something to read
+    if (data)
+    {
+        console.log(data);
+        console.log(data?.Content);
+        // Check to see if a milk bottle is used on the user
+        if (
+            data.Type === "Action" &&
+            data.Content === "ActionUse" &&
+            data.Dictionary[1]?.Tag === "DestinationCharacter" &&
+            data.Dictionary[1]?.MemberNumber === Player.MemberNumber &&
+            data.Dictionary[2]?.AssetName === "MilkBottle"
+        )
+        {
+            setDesperation();
+        }
+
+        // Starts the script running
+        if 
+        (
+            data.Content.startsWith("->diaper") &&
+            (data.Type === "Chat" || data.Type === "Whisper")
+        )
+        {
+            bcdwCommands(data.Content.substring(data.Content.length-5, data.Content.length), data.Sender);
+        }
+    }
+}
+
+// Command handler
+function bcdwCommands(data, callerID)
+{
+    console.log(data);
+    // Commands only the user can use
+    if (callerID === Player.MemberNumber)
+    {
+        // Start the script
+        if (data.startsWith("start"))
+        {
+            diaperWetter();
+        }
+    }
+}
+
 // Initializer function
 function diaperWetter()
 {
@@ -148,7 +196,6 @@ function setDesperation()
 {
     desperationLevel = 3;
 }
-// Will be called by chat handler once that is implemented
 
 // Handles "desperateness" aka how recently a milk bottle was drunk
 function manageDesperation(diaperTimerModifier = 1)

--- a/BCDiaperWetter.js
+++ b/BCDiaperWetter.js
@@ -27,6 +27,20 @@ DiaperUseMessages =
     "ChangeDiaperBoth": " has gotten a fresh pair of diapers."
 };
 
+// Table to store all the defaul values for diaperWetter()
+const diaperDefaultValues = 
+{
+    messChance: .3,
+    wetChance: .5,
+    baseTimer: 30,
+    regressionLevel: 0,
+    desperationLevel: 0,
+    messLevelInner: 0,
+    wetLevelInner: 0,
+    messLevelOuter: 0,
+    wetLevelOuter: 0
+};
+
 diaperLoop = null;         // Keeps a hold of the loop so it can be exited at any time easily
 
 // Destutter speach. Needed for interations with other mods
@@ -70,45 +84,135 @@ function bcdw(data)
             (data.Type === "Chat" || data.Type === "Whisper")
         )
         {
-            bcdwCommands(destutter(data?.Content).substring(9, data.Content.length), data.Sender);
+            // Parse out data into a queue for easier processing
+            chatCommand = data?.Content.split(" ");
+            chatCommand.shift();
+
+            // Send to command parser
+            bcdwCommands(chatCommand.reverse(), data.Sender);
         }
     }
 }
 
 // Command handler
-function bcdwCommands(data, callerID)
+function bcdwCommands(chatCommand, callerID)
 {
-    console.log(data);
     // Commands only the user can use
     if (callerID === Player.MemberNumber)
     {
         // Start the script
-        if (data.startsWith("start"))
+        if (chatCommand[chatCommand.length-1] === "start")
         {
-            diaperWetter();
+            // Check to see if other arguments have been passed as well (default regression level, desperation, or use levels)
+            chatCommand.pop()
+
+            // Parse arguments for command
+            let commandArguments = ["WetChance", "MessChance", "Desperation", "Regression", "Timer", "WetPanties", "MessPanties", "WetChastity", "MessChastity"];
+            let caughtArguments = {};
+            while (commandArguments.includes(chatCommand[chatCommand.length-1]))
+            {
+                let tempVal = chatCommand.pop();
+                switch (tempVal)
+                {
+                    case commandArguments[0]:
+                        caughtArguments.wetChance = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetChance : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[1]:
+                        caughtArguments.messChance = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messChance : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[2]:
+                        caughtArguments.desperationLevel = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.desperationLevel : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[3]:
+                        caughtArguments.regressionLevel = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.regressionLevel : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[4]:
+                        caughtArguments.baseTimer = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.baseTimer : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[5]:
+                        caughtArguments.wetLevelInner = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetLevelInner : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[6]:
+                        caughtArguments.messLevelInner = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messLevelInner : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[7]:
+                        caughtArguments.wetLevelOuter = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.wetLevelOuter : chatCommand[chatCommand.length-1];
+                        break;
+                    case commandArguments[8]:
+                        caughtArguments.messLevelOuter = (isNaN(chatCommand[chatCommand.length-1])) ? diaperDefaultValues.messLevelOuter : chatCommand[chatCommand.length-1];
+                        break;
+                }
+                chatCommand.pop();
+            }
+
+            console.log(caughtArguments);
+            diaperWetter(caughtArguments);
         }
 
         // End the script
-        if (data.startsWith("stop"))
+        else if (chatCommand[chatCommand.length-1] === "stop")
         {
             stopWetting();
         }
     }
+
+    // If the user is called out
+    else if (data.startsWith(toString(Player.MemberNumber)))
+    {
+        // Clip off the memeber number
+        data = data.substring(toString(Player.MemberNumber).length + 1, data.length);
+
+        if (data.startsWith("change"))
+        {
+            if (data.substring(7, data.length).startsWith("inner"))
+            {
+                refreshDiaper("panites");
+            }
+            else if (data.substring(7, data.length).startsWith("outer"))
+            {
+                refreshDiaper("chastity");
+            }
+            else
+            {
+                refreshDiaper();
+            }
+        }
+    }
 }
 
-
-
 // Initializer function
-function diaperWetter()
+function diaperWetter( args =
+    {
+        messChance: diaperDefaultValues.messChance,
+        wetChance: diaperDefaultValues.wetChance,
+        baseTimer: diaperDefaultValues.baseTimer,
+        regressionLevel: diaperDefaultValues.regressionLevel,
+        desperationLevel: diaperDefaultValues.desperationLevel,
+        messLevelInner: diaperDefaultValues.messLevelInner,
+        wetLevelInner: diaperDefaultValues.wetLevelInner,
+        messLevelOuter: diaperDefaultValues.messLevelOuter,
+        wetLevelOuter: diaperDefaultValues.wetLevelOuter
+    }
+)
 {
+    // Greating message
     ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: "Say hello to the little baby " + Player.Name + "!"}]});
+
     // Initial clear. Only time "both" should be used for refreshDiaper.
-    refreshDiaper("both");
-    messThreshold = .7;             // 1-chance to mess
-    wetThreshold = .5;              // 1-chance to wet
-    diaperTimerBase = 30;           // The default amount of time between ticks in minutes
-    regressionLevel = 0;            // Used for tracking how much the user has regressed (affects the timer)
-    desperationLevel = 0;           // Used for tracking how recently a milk bottle has been used (affects the timer)
+    refreshDiaper(
+    {
+        _diaper: "both",
+        _wetLevelChastity: (args.wetLevelOuter < 0 || args.wetLevelOuter > 2) ? diaperDefaultValues.wetLevelOuter : (args.wetLevelOuter > args.messLevelOuter) ? args.wetLevelOuter : args.messLevelOuter,
+        _messLevelChastity: (args.messLevelOuter < 0 || args.messLevelOuter > 2) ? diaperDefaultValues.messLevelOuter : args.messLevelOuter,
+        _wetLevelPanties: (args.wetLevelInner < 0 || args.wetLevelInner > 2) ? diaperDefaultValues.wetLevelInner : (args.wetLevelInner > args.messLevelInner) ? args.wetLevelInner : args.messLevelInner,
+        _messLevelPanties: (args.messLevelInner < 0 || args.messLevelInner > 2) ? diaperDefaultValues.messLevelInner : args.messLevelInner
+    });
+
+    messChance = args.messChance;
+    wetChance = args.wetChance;
+    diaperTimerBase = args.baseTimer;   // The default amount of time between ticks in minutes
+    regressionLevel = args.regressionLevel;// Used for tracking how much the user has regressed (affects the timer)
+    desperationLevel = args.desperationLevel;// Used for tracking how recently a milk bottle has been used (affects the timer)
     
 
     // Handle modifiers
@@ -133,14 +237,22 @@ function changeDiaperTimer(delay)
 }
 
 // Refresh the diaper settings so wet and mess levels are 0. Pass "chastity", "panties", or "both" so only the correct diaper gets reset.
-function refreshDiaper(diaper = "both")
-{
-    if (diaper === "both")
+function refreshDiaper({_diaper, _wetLevelPanties, _messLevelPanties, _wetLevelChastity, _messLevelChastity} =
     {
-        MessLevelPanties = 0;
-        WetLevelPanties = 0;
-        MessLevelChastity = 0;
-        WetLevelChastity = 0;
+        _diaper: "both",
+        _wetLevelPanties: diaperDefaultValues.wetLevelInner,
+        _messLevelPanties: diaperDefaultValues.messLevelInner,
+        _wetLevelChastity: diaperDefaultValues.wetLevelOuter,
+        _messLevelChastity: diaperDefaultValues.messLevelOuter,
+    }
+)
+{
+    if (_diaper === "both")
+    {
+        MessLevelPanties = _messLevelPanties;
+        WetLevelPanties = _wetLevelPanties;
+        MessLevelChastity = _messLevelChastity;
+        WetLevelChastity = _wetLevelChastity;
         changeDiaperColor("ItemPelvis");
         changeDiaperColor("Panties");
         if (checkForDiaper("Panties") && checkForDiaper("ItemPelvis"))
@@ -152,10 +264,10 @@ function refreshDiaper(diaper = "both")
             ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + DiaperUseMessages["ChangeDiaperOnly"]}]});
         }
     }
-    else if (diaper === "chastity")
+    else if (_diaper === "chastity")
     {
-        MessLevelChastity = 0;
-        WetLevelChastity = 0;
+        MessLevelChastity = _messLevelChastity;
+        WetLevelChastity = _wetLevelChastity;
         changeDiaperColor("ItemPelvis");
         if (checkForDiaper("ItemPelvis") && checkForDiaper("Panties"))
         {
@@ -166,10 +278,10 @@ function refreshDiaper(diaper = "both")
             ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + DiaperUseMessages["ChangeDiaperOnly"]}]});
         }
     }
-    else if (diaper === "panties")
+    else if (_diaper === "panties")
     {
-        MessLevelPanties = 0;
-        WetLevelPanties = 0;
+        MessLevelPanties = _messLevelPanties;
+        WetLevelPanties = _wetLevelPanties;
         changeDiaperColor("Panties");
         if (checkForDiaper("ItemPelvis") && checkForDiaper("Panties"))
         {
@@ -203,7 +315,7 @@ function checkForMilk()
 // Handles the regression counter
 function manageRegression(diaperTimerModifier = 1)
 {
-    if (checkForNurseryMilk() && regressionLevel < 6)
+    if (checkForNurseryMilk() && regressionLevel < 3)
     {
         regressionLevel++;
     }
@@ -309,7 +421,7 @@ function diaperTick()
 
     testMess = Math.random();
     // If the baby messes, increment the mess level to a max of 2 and make sure that the wet level is at least as high as the mess level.
-    if (testMess > messThreshold)
+    if (testMess > 1-messChance)
     {
         if (MessLevelPanties === 2 || !checkForDiaper("Panties"))
         {
@@ -352,7 +464,7 @@ function diaperTick()
         }
     }
     // If the baby only wets, increment the wet level to a max of 2.
-    else if (testMess > wetThreshold)
+    else if (testMess > 1-wetChance)
     {
         if (WetLevelPanties == 2 && (InventoryGet(Player, "Panties") !== "PoofyDiaper" && InventoryGet(Player, "Panties") !== "BulkyDiaper"))
         {

--- a/BCDiaperWetter.js
+++ b/BCDiaperWetter.js
@@ -108,7 +108,7 @@ function bcdwCommands(chatCommand, callerID)
 
             // Parse arguments for command
             let commandArguments = ["WetChance", "MessChance", "Desperation", "Regression", "Timer", "WetPanties", "MessPanties", "WetChastity", "MessChastity"];
-            let caughtArguments = {};
+            let caughtArguments = diaperDefaultValues;
             while (commandArguments.includes(chatCommand[chatCommand.length-1]))
             {
                 let tempVal = chatCommand.pop();
@@ -155,29 +155,6 @@ function bcdwCommands(chatCommand, callerID)
             stopWetting();
         }
     }
-
-    // If the user is called out
-    else if (data.startsWith(toString(Player.MemberNumber)))
-    {
-        // Clip off the memeber number
-        data = data.substring(toString(Player.MemberNumber).length + 1, data.length);
-
-        if (data.startsWith("change"))
-        {
-            if (data.substring(7, data.length).startsWith("inner"))
-            {
-                refreshDiaper("panites");
-            }
-            else if (data.substring(7, data.length).startsWith("outer"))
-            {
-                refreshDiaper("chastity");
-            }
-            else
-            {
-                refreshDiaper();
-            }
-        }
-    }
 }
 
 // Initializer function
@@ -199,15 +176,15 @@ function diaperWetter( args =
     ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: "Say hello to the little baby " + Player.Name + "!"}]});
 
     // Initial clear. Only time "both" should be used for refreshDiaper.
+
     refreshDiaper(
     {
-        _diaper: "both",
-        _wetLevelChastity: (args.wetLevelOuter < 0 || args.wetLevelOuter > 2) ? diaperDefaultValues.wetLevelOuter : (args.wetLevelOuter > args.messLevelOuter) ? args.wetLevelOuter : args.messLevelOuter,
-        _messLevelChastity: (args.messLevelOuter < 0 || args.messLevelOuter > 2) ? diaperDefaultValues.messLevelOuter : args.messLevelOuter,
-        _wetLevelPanties: (args.wetLevelInner < 0 || args.wetLevelInner > 2) ? diaperDefaultValues.wetLevelInner : (args.wetLevelInner > args.messLevelInner) ? args.wetLevelInner : args.messLevelInner,
-        _messLevelPanties: (args.messLevelInner < 0 || args.messLevelInner > 2) ? diaperDefaultValues.messLevelInner : args.messLevelInner
+        diaper: "both",
+        messLevelChastity: (isNaN(args.messLevelOuter) || (args.messLevelOuter < 0 || args.messLevelOuter > 2)) ? diaperDefaultValues.messLevelOuter : args.messLevelOuter,
+        wetLevelChastity: (isNaN(args.wetLevelOuter) || (args.wetLevelOuter < 0 || args.wetLevelOuter > 2)) ? (isNaN(args.messLevelOuter) || (args.messLevelOuter < 0 || args.messLevelOuter > 2)) ? diaperDefaultValues.messLevelOuter : args.messLevelOuter : (args.wetLevelOuter > args.messLevelOuter) ? args.wetLevelOuter : args.messLevelOuter,
+        messLevelPanties: (isNaN(args.messLevelInner) || (args.messLevelInner < 0 || args.messLevelInner > 2)) ? diaperDefaultValues.messLevelInner : args.messLevelInner,
+        wetLevelPanties: (isNaN(args.wetLevelInner) || (args.wetLevelInner < 0 || args.wetLevelInner > 2)) ? (isNaN(args.messLevelInner) || (args.messLevelInner < 0 || args.messLevelInner > 2)) ? diaperDefaultValues.messLevelInner : args.messLevelOuter : (args.wetLevelInner > args.messLevelInner) ? args.wetLevelInner : args.messLevelInner
     });
-
     messChance = args.messChance;
     wetChance = args.wetChance;
     diaperTimerBase = args.baseTimer;   // The default amount of time between ticks in minutes
@@ -237,22 +214,26 @@ function changeDiaperTimer(delay)
 }
 
 // Refresh the diaper settings so wet and mess levels are 0. Pass "chastity", "panties", or "both" so only the correct diaper gets reset.
-function refreshDiaper({_diaper, _wetLevelPanties, _messLevelPanties, _wetLevelChastity, _messLevelChastity} =
+function refreshDiaper(args =
     {
-        _diaper: "both",
-        _wetLevelPanties: diaperDefaultValues.wetLevelInner,
-        _messLevelPanties: diaperDefaultValues.messLevelInner,
-        _wetLevelChastity: diaperDefaultValues.wetLevelOuter,
-        _messLevelChastity: diaperDefaultValues.messLevelOuter,
+        diaper: "both",
+        wetLevelPanties: diaperDefaultValues.wetLevelInner,
+        messLevelPanties: diaperDefaultValues.messLevelInner,
+        wetLevelChastity: diaperDefaultValues.wetLevelOuter,
+        messLevelChastity: diaperDefaultValues.messLevelOuter,
     }
 )
 {
-    if (_diaper === "both")
+    if (args.diaper === "both")
     {
-        MessLevelPanties = _messLevelPanties;
-        WetLevelPanties = _wetLevelPanties;
-        MessLevelChastity = _messLevelChastity;
-        WetLevelChastity = _wetLevelChastity;
+        console.log(args.wetLevelPanties);
+        console.log(args.messLevelPanties);
+        console.log(args.wetLevelChastity);
+        console.log(args.messLevelChastity);
+        MessLevelPanties = args.messLevelPanties;
+        WetLevelPanties = args.wetLevelPanties;
+        MessLevelChastity = args.messLevelChastity;
+        WetLevelChastity = args.wetLevelChastity;
         changeDiaperColor("ItemPelvis");
         changeDiaperColor("Panties");
         if (checkForDiaper("Panties") && checkForDiaper("ItemPelvis"))
@@ -264,10 +245,10 @@ function refreshDiaper({_diaper, _wetLevelPanties, _messLevelPanties, _wetLevelC
             ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + DiaperUseMessages["ChangeDiaperOnly"]}]});
         }
     }
-    else if (_diaper === "chastity")
+    else if (args.diaper === "chastity")
     {
-        MessLevelChastity = _messLevelChastity;
-        WetLevelChastity = _wetLevelChastity;
+        MessLevelChastity = args.messLevelChastity;
+        WetLevelChastity = args.wetLevelChastity;
         changeDiaperColor("ItemPelvis");
         if (checkForDiaper("ItemPelvis") && checkForDiaper("Panties"))
         {
@@ -278,10 +259,10 @@ function refreshDiaper({_diaper, _wetLevelPanties, _messLevelPanties, _wetLevelC
             ServerSend("ChatRoomChat", {Type: "Action", Content: "gag", Dictionary: [{Tag: "gag", Text: Player.Name + DiaperUseMessages["ChangeDiaperOnly"]}]});
         }
     }
-    else if (_diaper === "panties")
+    else if (args.diaper === "panties")
     {
-        MessLevelPanties = _messLevelPanties;
-        WetLevelPanties = _wetLevelPanties;
+        MessLevelPanties = args.messLevelPanties;
+        WetLevelPanties = args.wetLevelPanties;
         changeDiaperColor("Panties");
         if (checkForDiaper("ItemPelvis") && checkForDiaper("Panties"))
         {

--- a/TODO
+++ b/TODO
@@ -3,13 +3,13 @@ BUG PRIORITY:
 
 HIGH PRIORITY:
 ✔ Chat messages when diaper is used. @done(22-02-27 20:25)
-☐ Chat based imports.
+✔ Chat based imports. @done(22-03-01 20:52)
 
 MEDIUM PRIORITY
 ☐ Generalize. Generalize. Generalize.
-    ☐ Make it so the timer length can be adjusted.
+    ✔ Make it so the timer length can be adjusted. @done(22-03-01 20:52)
 ☐ Separate front and back coloring.
-☐ Package based deployment.
+✔ Package based deployment. @done(22-02-27 22:53)
 
 LOW PRIORITY:
 ☐ UI configurator.


### PR DESCRIPTION
# Purpose of Commit
During testing for the previous commit, an error for when not all arguments were passed to the `->diaper start` command where it would not update the colors properly, and would hard lock the game if the color were to be checked. Fortunately, this did not corrupt any data irreparably.

# Bug Fixes
- Passing an incomplete set of commands to `->diaper start` now works as intended.

# Technical changes
- Changed `caughtArguments` in bcdwCommands to be initialized to a copy of `diaperDefaultValues` instead of an empty dictionary. This is what allowed for the bug to be fixed
- Updated `refreshDiaper()` to take arguments in the same manner as `diaperWetter()` for consistence's sake.